### PR TITLE
Unbreak the ES6 version of the app :(

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,6 @@
-var ReactDOM = require('react-dom');
-var App = require('./App');
+import React from 'react';
+import ReactDOM from 'react-dom';
+import App from './App';
+import './index.css';
 
 ReactDOM.render(<App />, document.getElementById('root'));


### PR DESCRIPTION
Sorry... PR #5 broke the ES6 version of the app because I didn't refresh the
page to test it out. Removing the registerServiceWorker did, in fact, make it
harder for me to find this bug because auto-refresh went away! My bad. :(

I created PR #5 by cherry-picking a commit from PR #4. However,
that also brought over the removal of index.js ES6 usage, which
we did NOT want.
Restoring the usage of 'import' fixes the app.